### PR TITLE
Pass through missing methods in section blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.1.0] - TBD
+- Methods from the calling context can now be called within a section block.
+
 ## [3.0.2] - 2022-04-16
 - Fix tests on ruby 3.0.
 - More adjustments and additions to docs.

--- a/lib/slack_message/dsl.rb
+++ b/lib/slack_message/dsl.rb
@@ -272,6 +272,10 @@ class SlackMessage::Dsl
 
       body
     end
+
+    def method_missing(meth, *args, &blk)
+      @parent.send meth, *args, &blk
+    end
   end
 
   class List

--- a/slack_message.gemspec
+++ b/slack_message.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'slack_message'
-  gem.version     = "3.0.2"
+  gem.version     = "3.1.0"
   gem.summary     = "A nice DSL for composing rich messages in Slack"
   gem.authors     = ["Joe Mastey"]
   gem.email       = 'hello@joemastey.com'

--- a/spec/slack_message_spec.rb
+++ b/spec/slack_message_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe SlackMessage do
 
   describe "DSL" do
     describe "#build" do
+      def outer_method
+       "foo"
+      end
+
       it "renders some JSON" do
         SlackMessage.configure do |config|
           config.clear_profiles!
@@ -13,11 +17,17 @@ RSpec.describe SlackMessage do
         expected_output = [
           { type: "section",
             text: { text: "foo", type: "mrkdwn" }
-          }
+          },
+          { type: "section",
+            text: { text: "foo", type: "mrkdwn" }
+          },
         ]
 
         output = SlackMessage.build do
-          text "foo"
+          text outer_method()
+          section do
+            text outer_method()
+          end
         end
 
         expect(output).to eq(expected_output)


### PR DESCRIPTION
Inside of a section block, currently missing methods do not get passed through to the parent context.