### PR TITLE
fix some name reference issues around user lookup error handling.

### DIFF
--- a/lib/slack_message/api.rb
+++ b/lib/slack_message/api.rb
@@ -22,13 +22,10 @@ module SlackMessage::Api
       raise SlackMessage::ApiError, "Received empty 200 response from Slack when looking up user info. Check your API key."
     end
 
-    begin
-      payload = JSON.parse(response.body)
-    rescue
-      raise SlackMessage::ApiError, "Unable to parse JSON response from Slack API\n#{response.body}"
-    end
+    SlackMessage::ErrorHandling.raise_user_lookup_response_errors(response, email, profile)
 
-    SlackMessage::ErrorHandling.raise_user_lookup_errors(response, target, profile)
+    payload = JSON.parse(response.body)
+
     payload["user"]["id"]
   end
 

--- a/lib/slack_message/error_handling.rb
+++ b/lib/slack_message/error_handling.rb
@@ -102,7 +102,13 @@ class SlackMessage::ErrorHandling
     end
   end
 
-  def self.raise_user_lookup_response_errors(payload)
+  def self.raise_user_lookup_response_errors(response, email, profile)
+    begin
+      payload = JSON.parse(response.body)
+    rescue
+      raise SlackMessage::ApiError, "Unable to parse JSON response from Slack API\n#{response.body}"
+    end
+
     error = payload["error"]
 
     if error == "users_not_found"

--- a/spec/slack_message_spec.rb
+++ b/spec/slack_message_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SlackMessage do
       end
     end
 
-    fit do
+    it do
       SlackMessage.build do
         notification_text 'one'
         notification_text 'two'

--- a/spec/slack_message_spec.rb
+++ b/spec/slack_message_spec.rb
@@ -60,13 +60,6 @@ RSpec.describe SlackMessage do
       end
     end
 
-    it do
-      SlackMessage.build do
-        notification_text 'one'
-        notification_text 'two'
-      end
-    end
-
     it "can assert expectations against posts" do
       expect {
         SlackMessage.post_to('#lieutenant') { text "foo" }


### PR DESCRIPTION
We were noticing some 500 errors on our deploy messages as of late, especially since reconnecting our Heroku to Github.

The errors were `NoMethodError`s on the `target` reference on line 31 of `SlackMessage::Api`.

Upon further review, it looked like _maybe_ this error handling refactor wasn't completely finished in the latest version of the code because the method on error handling was also mis-referenced.

I took the opportunity to also move the json parse error into the error handling method at the same time because it looked like it matched the pattern of other error handling methods nearby.

Note, however, that I did not verify all of the _actual_ error handling code to make sure it was doing sane things. Looking at the commit history it looks to _mostly_ be copy/paste from an earlier time when the same sorts of error handling conditions were inline within the `user_id_for` method.