### PR TITLE
Provide more debugging info for blocks errors

### DIFF
--- a/lib/slack_message/api.rb
+++ b/lib/slack_message/api.rb
@@ -85,8 +85,6 @@ module SlackMessage::Api
     end
 
     response = update_message(profile, params)
-    body  = JSON.parse(response.body)
-    error = body.fetch("error", "")
 
     SlackMessage::ErrorHandling.raise_update_response_errors(response, params, profile)
     SlackMessage::Response.new(response, profile[:handle])

--- a/lib/slack_message/api.rb
+++ b/lib/slack_message/api.rb
@@ -88,7 +88,7 @@ module SlackMessage::Api
     body  = JSON.parse(response.body)
     error = body.fetch("error", "")
 
-    SlackMessage::ErrorHandling.raise_post_response_errors(response, message, profile)
+    SlackMessage::ErrorHandling.raise_update_response_errors(response, params, profile)
     SlackMessage::Response.new(response, profile[:handle])
   end
 

--- a/lib/slack_message/error_handling.rb
+++ b/lib/slack_message/error_handling.rb
@@ -7,8 +7,10 @@ class SlackMessage::ErrorHandling
     body  = JSON.parse(response.body)
     error = body.fetch("error", "")
 
-    if ["invalid_blocks", "invalid_blocks_format"].include?(error)
-      raise SlackMessage::ApiError, "Couldn't send Slack message because the serialized message had an invalid format"
+    if error == "invalid_blocks"
+      raise SlackMessage::ApiError, "Couldn't send Slack message because the request contained invalid blocks:\n#{JSON.pretty_generate(params[:blocks])}"
+    elsif error == "invalid_blocks_format"
+      raise SlackMessage::ApiError, "Couldn't send Slack message because blocks is not a valid JSON object or doesn't match the Block Kit syntax:\n#{JSON.pretty_generate(params[:blocks])}"
     elsif error == "channel_not_found"
       raise SlackMessage::ApiError, "Tried to send Slack message to non-existent channel or user '#{params[:channel]}'"
 

--- a/lib/slack_message/error_handling.rb
+++ b/lib/slack_message/error_handling.rb
@@ -36,7 +36,7 @@ class SlackMessage::ErrorHandling
     elsif response.code != "200"
       raise SlackMessage::ApiError, "Got an error back from the Slack API (HTTP #{response.code}):\n#{response.body}"
     elsif !(error.nil? || error == "")
-      raise SlackMessage::ApiError, "Received error response from Slack during message posting:\n#{response.body}"
+      raise SlackMessage::ApiError, "Received error response '#{error}' from Slack during message posting:\n#{response.body}"
     end
   end
 
@@ -49,10 +49,10 @@ class SlackMessage::ErrorHandling
     elsif error == "invalid_blocks_format"
       raise SlackMessage::ApiError, "Couldn't update Slack message because blocks is not a valid JSON object or doesn't match the Block Kit syntax:\n#{blocks_message(params[:blocks])}"
     elsif error == "channel_not_found"
-      raise SlackMessage::ApiError, "Tried to update Slack message to non-existent channel or user '#{params.channel}'"
+      raise SlackMessage::ApiError, "Tried to update Slack message to non-existent channel or user '#{params[:channel]}'"
 
     elsif error == "message_not_found"
-      raise SlackMessage::ApiError, "Tried to update Slack message, but the message wasn't found (timestamp '#{params.ts}' for channel '#{params.channel}'"
+      raise SlackMessage::ApiError, "Tried to update Slack message, but the message wasn't found (timestamp '#{params[:ts]}' for channel '#{params[:channel]}'"
     elsif error == "cant_update_message"
       raise SlackMessage::ApiError, "Couldn't update message because the message type isn't able to be updated, or #{profile[:handle]} isn't allowed to update it"
     elsif error == "edit_window_closed"
@@ -72,7 +72,7 @@ class SlackMessage::ErrorHandling
     elsif response.code != "200"
       raise SlackMessage::ApiError, "Got an error back from the Slack API (HTTP #{response.code}):\n#{response.body}"
     elsif !(error.nil? || error == "")
-      raise SlackMessage::ApiError, "Received error response from Slack during message update:\n#{response.body}"
+      raise SlackMessage::ApiError, "Received error response '#{error}' from Slack during message update:\n#{response.body}"
     end
   end
 
@@ -102,7 +102,7 @@ class SlackMessage::ErrorHandling
     elsif response.code != "200"
       raise SlackMessage::ApiError, "Got an error back from the Slack API (HTTP #{response.code}):\n#{response.body}"
     elsif !(error.nil? || error == "")
-      raise SlackMessage::ApiError, "Received error response from Slack during message delete:\n#{response.body}"
+      raise SlackMessage::ApiError, "Received error response '#{error}' from Slack during message delete:\n#{response.body}"
     end
   end
 

--- a/lib/slack_message/error_handling.rb
+++ b/lib/slack_message/error_handling.rb
@@ -40,17 +40,17 @@ class SlackMessage::ErrorHandling
     end
   end
 
-  def self.raise_update_response_errors(response, message, profile)
+  def self.raise_update_response_errors(response, params, profile)
     body  = JSON.parse(response.body)
     error = body.fetch("error", "")
 
     if ["invalid_blocks", "invalid_blocks_format"].include?(error)
       raise SlackMessage::ApiError, "Couldn't update Slack message because the serialized message had an invalid format"
     elsif error == "channel_not_found"
-      raise SlackMessage::ApiError, "Tried to update Slack message to non-existent channel or user '#{message.channel}'"
+      raise SlackMessage::ApiError, "Tried to update Slack message to non-existent channel or user '#{params.channel}'"
 
     elsif error == "message_not_found"
-      raise SlackMessage::ApiError, "Tried to update Slack message, but the message wasn't found (timestamp '#{message.timestamp}' for channel '#{message.channel}'"
+      raise SlackMessage::ApiError, "Tried to update Slack message, but the message wasn't found (timestamp '#{params.ts}' for channel '#{params.channel}'"
     elsif error == "cant_update_message"
       raise SlackMessage::ApiError, "Couldn't update message because the message type isn't able to be updated, or #{profile[:handle]} isn't allowed to update it"
     elsif error == "edit_window_closed"


### PR DESCRIPTION
## Description
👋🏻 This PR disambiguates the `invalid_blocks` and `invalid_blocks_format` errors, and includes the blocks data in the error message so that the source of the error can be identified.

See https://api.slack.com/methods/chat.postMessage#errors