### PR TITLE
Validate message block limit

### DIFF
--- a/lib/slack_message/api.rb
+++ b/lib/slack_message/api.rb
@@ -41,6 +41,10 @@ module SlackMessage::Api
       raise ArgumentError, "Tried to send an entirely empty message."
     end
 
+    if params[:blocks].length > 50
+      raise ArgumentError, "Message cannot contain more than 50 blocks"
+    end
+
     icon = payload.custom_bot_icon || profile[:icon]
     if icon =~ /^:\w+:$/
       params[:icon_emoji] = icon
@@ -78,6 +82,10 @@ module SlackMessage::Api
 
     if params[:blocks].length == 0
       raise ArgumentError, "Tried to send an entirely empty message."
+    end
+
+    if params[:blocks].length > 50
+      raise ArgumentError, "Message cannot contain more than 50 blocks"
     end
 
     if SlackMessage::Configuration.debugging?

--- a/lib/slack_message/api.rb
+++ b/lib/slack_message/api.rb
@@ -42,7 +42,7 @@ module SlackMessage::Api
     end
 
     if params[:blocks].length > 50
-      raise ArgumentError, "Message cannot contain more than 50 blocks"
+      raise ArgumentError, "Message cannot contain more than 50 blocks."
     end
 
     icon = payload.custom_bot_icon || profile[:icon]

--- a/lib/slack_message/api.rb
+++ b/lib/slack_message/api.rb
@@ -85,7 +85,7 @@ module SlackMessage::Api
     end
 
     if params[:blocks].length > 50
-      raise ArgumentError, "Message cannot contain more than 50 blocks"
+      raise ArgumentError, "Message cannot contain more than 50 blocks."
     end
 
     if SlackMessage::Configuration.debugging?


### PR DESCRIPTION
## Description
Slack's API will reject messages with more than 50 blocks. This PR adds validation to ensure we don't send more than 50 blocks.

See https://api.slack.com/reference/block-kit/blocks